### PR TITLE
video_id param sequence

### DIFF
--- a/lib/vimeo/advanced/video.rb
+++ b/lib/vimeo/advanced/video.rb
@@ -105,7 +105,7 @@ module Vimeo
 
       create_api_method :set_title,
                         "vimeo.videos.setTitle",
-                        :required => [:title, :video_id]
+                        :required => [:video_id, :title]
       
       # comments
       create_api_method :add_comment,


### PR DESCRIPTION
In example: video.set_title("video_id", "title") => internal error
works only after shift: video.set_title("title", "video_id") => just fine
