### PR TITLE
Added a missing require 'crack' statement. 

### DIFF
--- a/lib/vimeo/advanced/base.rb
+++ b/lib/vimeo/advanced/base.rb
@@ -1,4 +1,5 @@
 require 'oauth'
+require 'crack'
 
 module CreateApiMethod
   


### PR DESCRIPTION
When trying to run the Vimeo::Advanced::Upload#get_quota method I kept getting this error message:
uninitialized constant Vimeo::Advanced::Base::Crack
lib/vimeo/advanced/base.rb:104:in `make_request'

I understand the code is trying to parse the JSON response using the crack gem "http://rubygems.org/gems/crack" which for some reason is not being loaded. 

My quick and dirty fix was to add the require line directly onto the source of the gem. It seems to work now but there might be a better way to do this, I have little experience developing gems.
