### PR TITLE
Changed get_comments_list to be unauthorized request 

### DIFF
--- a/lib/vimeo/advanced/video.rb
+++ b/lib/vimeo/advanced/video.rb
@@ -128,7 +128,8 @@ module Vimeo
       create_api_method :get_comments_list,
                         "vimeo.videos.comments.getList",
                         :required => [:video_id],
-                        :optional => [:page, :per_page]
+                        :optional => [:page, :per_page],
+                        :authorized => false
       
       # embed
       # getPresets has a bug right now: the response is blank http://www.vimeo.com/forums/topic:32411


### PR DESCRIPTION
The Vimeo API documentation states that the comment list method does not require authorization, so I just changed the source to reflect this. All the tests still pass after this change.

Docs: http://vimeo.com/api/docs/methods/vimeo.videos.comments.getList

Thanks
