### PR TITLE
Resolved Issue #39

### DIFF
--- a/lib/vimeo/advanced/simple_upload/chunk.rb
+++ b/lib/vimeo/advanced/simple_upload/chunk.rb
@@ -18,7 +18,7 @@ module Vimeo
 
         # Performs the upload via Multipart.
         def upload
-          endpoint = "#{task.endpoint}&chunk_id=#{index}"
+          endpoint = "#{task.endpoint}"
 
           response = task.oauth_consumer.request(:post, endpoint, vimeo.get_access_token, {}, {}) do |req|
             req.set_content_type("multipart/form-data", { "boundary" => MULTIPART_BOUNDARY })
@@ -29,6 +29,8 @@ module Vimeo
             def io.content_type; "application/octet-stream"; end
 
             parts = []
+            parts << Parts::ParamPart.new(MULTIPART_BOUNDARY, "ticket_id", task.id)
+            parts << Parts::ParamPart.new(MULTIPART_BOUNDARY, "chunk_id", index)
             parts << Parts::FilePart.new(MULTIPART_BOUNDARY, "file_data", io)
             parts << Parts::EpiloguePart.new(MULTIPART_BOUNDARY)
 

--- a/lib/vimeo/advanced/simple_upload/task.rb
+++ b/lib/vimeo/advanced/simple_upload/task.rb
@@ -69,7 +69,7 @@ module Vimeo
 
         # Returns a hash of the sent chunks and their respective sizes.
         def sent_chunk_sizes
-          Hash[chunks.map { |chunk| [chunk.id, chunk.size] }]
+          Hash[chunks.map { |chunk| [chunk.index.to_s, chunk.size] }]
         end
 
         # Returns a of Vimeo's received chunks and their respective sizes.


### PR DESCRIPTION
Vimeo backend API changes seem to require more strict adherence to the Advanced API spec. Now including required POST parameters in the multipart section of the upload, rather than in the URL.

Additionally adjusted the chunk verification code to use the chunk index rather than the non-existent chunk id.

Videos seem to be uploading fine with these changes.
