### PR TITLE
simple upload was missing size parameter

### DIFF
--- a/lib/vimeo/advanced/simple_upload.rb
+++ b/lib/vimeo/advanced/simple_upload.rb
@@ -7,14 +7,14 @@ module Vimeo
       autoload :Chunk,        'vimeo/advanced/simple_upload/chunk'
 
       # Uploads data (IO streams or files) to Vimeo.
-      def upload(uploadable)
+      def upload(uploadable, size = 0)
         case uploadable
         when File, Tempfile
           upload_file(uploadable)
         when String
           upload_file(File.new(uploadable))
         else
-          upload_io(uploadable)
+          upload_io(uploadable, size)
         end
       end
 


### PR DESCRIPTION
The method `upload` would accept an IO object as uploadable but would not accept a size parameter which would be required later for IO streaming. I simply included a second parameter for this method: `integer size`.
