### PR TITLE
Use HTTPS for Vimeo OAuth and endpoint requests.

### DIFF
--- a/lib/vimeo/advanced/base.rb
+++ b/lib/vimeo/advanced/base.rb
@@ -67,10 +67,10 @@ module Vimeo
     class Base
       extend CreateApiMethod
 
-      ENDPOINT = "http://vimeo.com/api/rest/v2"
+      ENDPOINT = "https://vimeo.com/api/rest/v2"
 
       def initialize(consumer_key, consumer_secret, options = {})
-        @oauth_consumer = OAuth::Consumer.new(consumer_key, consumer_secret, :site => 'http://vimeo.com', :http_method => :get, :scheme => :header)
+        @oauth_consumer = OAuth::Consumer.new(consumer_key, consumer_secret, :site => 'https://vimeo.com', :http_method => :get, :scheme => :header)
         unless options[:token].nil? && options[:secret].nil?
           @access_token = OAuth::AccessToken.new(@oauth_consumer, options[:token], options[:secret])
         end

--- a/lib/vimeo/simple/base.rb
+++ b/lib/vimeo/simple/base.rb
@@ -3,7 +3,7 @@ module Vimeo
     
     class Base      
       include HTTParty
-      base_uri 'vimeo.com/api/v2'
+      base_uri 'https://vimeo.com/api/v2'
     end # Base
 
   end # Simple

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,7 +31,7 @@ def fixture_file(filename)
 end
 
 def vimeo_base_url(url = "/")
-  "http://vimeo.com#{url}"
+  "https://vimeo.com#{url}"
 end
 
 def vimeo_url(url = "")

--- a/test/vimeo/advanced/auth_test.rb
+++ b/test/vimeo/advanced/auth_test.rb
@@ -15,7 +15,7 @@ class AuthTest < Test::Unit::TestCase
       stub_custom_get("/oauth/request_token", "advanced/auth/request_token.txt")
       token = @auth.get_request_token
       assert_equal true, token.callback_confirmed?
-      assert_equal "http://vimeo.com/oauth/authorize?oauth_token=#{TOKEN}", token.authorize_url
+      assert_equal "https://vimeo.com/oauth/authorize?oauth_token=#{TOKEN}", token.authorize_url
     end
 
     should "receive the user's credentials after checking the OAuth token" do


### PR DESCRIPTION
Using HTTPS ensures, among other advantages, that URLs to assets returned by (e.g.) the videos endpoint will point to the version of the resource served over HTTPS, so that we get `https://secure-b.vimeocdn...` instead of `http://b.vimeocdn...`.

I was unable to check whether this breaks any specs, as I couldn't get the test suite to run -- #33.
