### PR TITLE
Don't authorize Advanced::Channel#get_videos request

### DIFF
--- a/lib/vimeo/advanced/channel.rb
+++ b/lib/vimeo/advanced/channel.rb
@@ -33,8 +33,9 @@ module Vimeo
       create_api_method :get_videos,
                         "vimeo.channels.getVideos",
                         :required => [:channel_id],
-                        :optional => [:page, :per_page, :full_response]
+                        :optional => [:page, :per_page, :full_response],
                         
+                        :authorized => false
       # Removes a video from a channel.
       create_api_method :remove_video,
                         "vimeo.channels.removeVideo",


### PR DESCRIPTION
The get_videos request for Channel doesn't need to be authorized, and I'm not authorizing a user in my app, so that was failing for me. 
