### PR TITLE
Add the posibility to use a vimeo URL to get video information

### DIFF
--- a/lib/vimeo/simple/video.rb
+++ b/lib/vimeo/simple/video.rb
@@ -4,9 +4,10 @@ module Vimeo
     class Video < Vimeo::Simple::Base
       # Returns this video's information.
       #
-      # @param [String] video_id The video's id.
+      # @param [String] video_id The video's id or a valid vimeo url.
       def self.info(video_id)
-        get("/video/#{video_id}.json")
+        video_id.to_s.match(/(?:http(?:s)?:\/\/)?vimeo.com\/(\d+)/)
+        get("/video/#{$1 || video_id}.json")
       end
     end
 

--- a/test/vimeo/simple/video_test.rb
+++ b/test/vimeo/simple/video_test.rb
@@ -6,6 +6,7 @@ class VideoTest < Test::Unit::TestCase
     
     setup do
       @video_id = "411684"
+      @vimeo_url = "http://vimeo.com/#{@video_id}"
     end
     
     context "making api calls" do
@@ -13,6 +14,13 @@ class VideoTest < Test::Unit::TestCase
       should "be able to get information about a video" do
         stub_get("/video/#{@video_id}.json", "simple/video/info.json")
         info = Vimeo::Simple::Video.info(@video_id).first
+        
+        assert_equal "411684", info["id"]
+      end
+
+      should "be able to use a vimeo url to get information about a video" do
+        stub_get("/video/#{@video_id}.json", "simple/video/info.json")
+        info = Vimeo::Simple::Video.info(@vimeo_url).first
         
         assert_equal "411684", info["id"]
       end


### PR DESCRIPTION
Hi!

I don't know if this is a desired feature but using the gem along side others like [youtube_it](https://github.com/kylejginavan/youtube_it) it's useful to be able to use a Vimeo URL to get the information from the video, instead of having to strip the id before time.

If it's useful I can add info to the README and squash it with this commit.

Thanks!
